### PR TITLE
refactor: update macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ pub fn main() {
     mist_service!(
         {
             actions: {
-                // "action": handler
+                // (Required) "action": handler
+                // Type: FnOnce(Vec<u8>, Envelope) -> Result<(), String>
                 "hello": handle_english_action,
                 "hola": handle_spanish_action
             },
-            // Optional init field
+            // (Optional) init: init_handler
+            // Type FnOnce() -> Result<(), &'static str>
             init: init
         }
     )

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Optionally, you can provide an `init` function.
 ```rust
 use mist_tools_rust::{mist_service, Envelope};
 
-pub fn main() {
+// Requires main returns Result<(), String>
+pub fn main() -> Result<(), String> {
     mist_service!(
         {
             actions: {

--- a/src/mist.rs
+++ b/src/mist.rs
@@ -47,7 +47,7 @@ where
     Ok(())
 }
 
-fn get_payload() -> Result<Vec<u8>, &'static str> {
+pub fn get_payload() -> Result<Vec<u8>, &'static str> {
     let mut buffer = Vec::new();
     io::stdin()
         .read_to_end(&mut buffer)
@@ -55,29 +55,29 @@ fn get_payload() -> Result<Vec<u8>, &'static str> {
     Ok(buffer)
 }
 
-fn get_args() -> Result<(String, Envelope), String> {
-    let args = env::args().rev().take(2);
+pub fn get_args() -> Result<(String, Envelope), String> {
+    let args = env::args();
     if args.len() < 3 {
-        Err("Insufficient program arguments".to_string())
-    } else {
-        let mut action = None;
-        let mut envelope = None;
-        for (i, arg) in args.enumerate() {
-            match i {
-                0 => {
-                    action = Some(arg);
-                }
-                1 => {
-                    envelope = Some(Envelope::new(arg.as_str())?);
-                }
-                _ => unreachable!(),
+        return Err("Insufficient program arguments".to_string());
+    }
+    let args = args.rev().take(2);
+    let mut action = None;
+    let mut envelope = None;
+    for (i, arg) in args.enumerate() {
+        match i {
+            0 => {
+                action = Some(arg);
             }
-        }
-        match (action, envelope) {
-            (Some(a), Some(e)) => Ok((a, e)),
-            (None, _) => Err("Unable to get action".to_string()),
+            1 => {
+                envelope = Some(Envelope::new(arg.as_str())?);
+            }
             _ => unreachable!(),
         }
+    }
+    match (action, envelope) {
+        (Some(a), Some(e)) => Ok((a, e)),
+        (None, _) => Err("Unable to get action".to_string()),
+        _ => unreachable!(),
     }
 }
 


### PR DESCRIPTION
Now inlines the pattern match for action handlers in the macro, so we avoid dynamic lookup of handlers.